### PR TITLE
fix display cutout / notch support

### DIFF
--- a/project/app/src/main/res/layout-land/preview_activity.xml
+++ b/project/app/src/main/res/layout-land/preview_activity.xml
@@ -2,6 +2,7 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:alpha="0"
@@ -34,11 +35,12 @@
         android:id="@+id/move_btn_container"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_gravity="end"
-        android:layout_marginEnd="16dp"
+        android:layout_gravity="right"
+        android:layout_marginRight="16dp"
         android:orientation="vertical"
         android:paddingTop="16dp"
-        android:paddingBottom="16dp">
+        android:paddingBottom="16dp"
+        tools:ignore="RtlHardcoded">
 
         <ImageButton
             android:id="@+id/up"
@@ -110,8 +112,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
         android:padding="4dp"
         app:cardCornerRadius="8dp"
         app:cardElevation="0dp"


### PR DESCRIPTION
currently the support for notch is broken. mainly because we didn't reassign layoutParams to the view so the new params won't apply.

to solved this. I rewritten the logic and improve the notch handling.
- fixed the bug that layoutParams is not reassigned
- toolbar's background is expanded under the notch area.
- always set `seekbarCard` width to 50% (no matter the OS version) to make room for `moveBtnContainer`
- handles display cutout from every direction
- changed some layout attributes
  - removed `seekbarCard` vertical margin in landscape mode because we are setting its width 50% anyway.
  - added a marginBottom to `seekbarCard`.
  - changed `moveBtnContainer` marginEnd to marginRight because we are setting marginRight in the code and marginRight and marginEnd cannot be set at the same time. I also ignored the `RtlHardcoded` warning because this won't really break RTL support.

### test screenshots:

I test some scenarios with notch emulation in the developers options menu.

notch on the top and bottom

<img src="https://user-images.githubusercontent.com/1688764/183748984-e0f8cb8d-fdbb-4146-82c7-67d51a0dd941.png" height="469" />

<img src="https://user-images.githubusercontent.com/1688764/183749019-7a948159-318d-4555-9af0-070cacdd85e7.png" width="469" />

notch in the corner: 

<img src="https://user-images.githubusercontent.com/1688764/183749083-2adcc5fd-69a1-44d2-92a5-e42e0c8cc1aa.png" height="469" />

<img src="https://user-images.githubusercontent.com/1688764/183749111-695484a4-3653-4971-8548-8e61c524f02e.png" width="469" />

<img src="https://user-images.githubusercontent.com/1688764/183749124-fe6fdfc6-a6b6-49d5-84d5-c80029d084ed.png" width="469" />

